### PR TITLE
Handle catastrophic JSoup errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ buildscript {
     repositories {
         maven { url 'https://github.com/leonardocardoso/mvn-repo/raw/master/maven-deploy' }
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.0'
@@ -17,5 +21,9 @@ allprojects {
     repositories {
         maven { url 'https://github.com/leonardocardoso/mvn-repo/raw/master/maven-deploy' }
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,10 +5,12 @@ android {
     buildToolsVersion '25.0.0'
 
     defaultConfig {
-        minSdkVersion 7
+        minSdkVersion 9
         targetSdkVersion 23
         versionCode 1
         versionName "1.2.2"
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -21,4 +23,7 @@ android {
 
 dependencies {
     compile 'org.jsoup:jsoup:1.10.3'
+
+    androidTestCompile 'junit:junit:4.12'
+    androidTestCompile 'com.android.support.test:runner:1.0.1'
 }

--- a/library/src/androidTest/java/com/leocardz/link/preview/library/TextCrawlerTest.java
+++ b/library/src/androidTest/java/com/leocardz/link/preview/library/TextCrawlerTest.java
@@ -1,0 +1,74 @@
+package com.leocardz.link.preview.library;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.jsoup.nodes.Document;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Instrumentation tests for TextCrawler.
+ */
+@RunWith(AndroidJUnit4.class)
+public class TextCrawlerTest {
+    @Test
+    public void catastrophicJSoupErrorMarksSourceContentAsFailed() throws Throwable {
+        final CountDownLatch signal = new CountDownLatch(1);
+        final JSoupFailingTextCrawler textCrawler = new JSoupFailingTextCrawler();
+
+        final TestLinkPreviewCallback callback = new TestLinkPreviewCallback(signal);
+        textCrawler.makePreview(callback, "http://www.google.com");
+        signal.await();
+
+        assertNotNull(callback.sourceContent);
+        assertFalse(callback.sourceContent.isSuccess());
+        assertTrue(callback.isNull);
+    }
+
+    /**
+     * A TextCrawler that mimics a catastrophic failure in JSoup.
+     */
+    private class JSoupFailingTextCrawler extends TextCrawler {
+
+        @Override
+        protected GetCode createPreviewGenerator(int imageQuantity) {
+            return new GetCode(imageQuantity) {
+
+                @Override
+                protected Document getDocument() throws IOException {
+                    throw new Error("catastrophic JSoup error has occurred.");
+                }
+            };
+        }
+    }
+
+    private class TestLinkPreviewCallback implements LinkPreviewCallback {
+        SourceContent sourceContent;
+        boolean isNull;
+        final CountDownLatch signal;
+
+        public TestLinkPreviewCallback(CountDownLatch signal) {
+            super();
+            this.signal = signal;
+        }
+
+        @Override
+        public void onPre() {
+
+        }
+
+        @Override
+        public void onPos(SourceContent sourceContent, boolean isNull) {
+            this.sourceContent = sourceContent;
+            this.isNull = isNull;
+            signal.countDown();
+        }
+    }
+}

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
-<manifest package="com.leocardz.link.preview.library" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.leocardz.link.preview.library">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/library/src/main/java/com/leocardz/link/preview/library/TextCrawler.java
+++ b/library/src/main/java/com/leocardz/link/preview/library/TextCrawler.java
@@ -38,7 +38,11 @@ public class TextCrawler {
 							int imageQuantity) {
 		this.callback = callback;
 		cancel();
-		getCodeTask = new GetCode(imageQuantity).execute(url);
+		getCodeTask = createPreviewGenerator(imageQuantity).execute(url);
+	}
+
+	protected GetCode createPreviewGenerator(int imageQuantity) {
+		return new GetCode(imageQuantity);
 	}
 
 	public void cancel(){
@@ -103,9 +107,7 @@ public class TextCrawler {
 
 				} else {
 					try {
-						Document doc = Jsoup
-								.connect(sourceContent.getFinalUrl())
-								.userAgent("Mozilla").get();
+						Document doc = getDocument();
 
 						sourceContent.setHtmlCode(extendedTrim(doc.toString()));
 
@@ -147,7 +149,7 @@ public class TextCrawler {
 						}
 
 						sourceContent.setSuccess(true);
-					} catch (Exception e) {
+					} catch (Throwable t) {
 						sourceContent.setSuccess(false);
 					}
 				}
@@ -164,10 +166,14 @@ public class TextCrawler {
 			return null;
 		}
 
+		protected Document getDocument() throws IOException {
+			return Jsoup.connect(sourceContent.getFinalUrl()).userAgent("Mozilla").get();
+		}
+
 		/** Verifies if the content could not be retrieved */
 		public boolean isNull() {
-			return !sourceContent.isSuccess() && 
-				extendedTrim(sourceContent.getHtmlCode()).equals("") && 
+			return !sourceContent.isSuccess() &&
+				extendedTrim(sourceContent.getHtmlCode()).equals("") &&
 				!isImage(sourceContent.getFinalUrl());
 		}
 
@@ -180,7 +186,7 @@ public class TextCrawler {
 		String result = "", currentMatch = "";
 
 		List<String> matches = Regex.pregMatchAll(content, pattern, 2);
-		
+
 		int matchesSize = matches.size();
 		for (int i = 0; i < matchesSize; i++) {
 			if(getCodeTask.isCancelled()){


### PR DESCRIPTION
- Add the Internet permission at the library level since any user of the library will need it
- Add the Google maven repository so that the Android testing libraries can be pulled down
- Bump the minSdkVersion so that the Google testing library can be used
- Add the Android Testing library and JUnit
- Refactor some methods in TextCrawler to facilitate testing
- Add a test for TextCrawler to replicate what occurs when JSoup has a catastrophic error