### PR TITLE
Add ability for library user to change how the library retrieves images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
 
     dexOptions {
         jumboMode = true
@@ -24,9 +23,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.koushikdutta.urlimageviewhelper:urlimageviewhelper:1.0.4'
-    compile 'org.jsoup:jsoup:1.8.3'
-    compile 'com.leocardz:link-preview:2.0.0@aar'
+    implementation 'com.android.support:appcompat-v7:23.1.1'
+    implementation 'com.koushikdutta.urlimageviewhelper:urlimageviewhelper:1.0.4'
+    implementation 'org.jsoup:jsoup:1.11.3'
+    implementation 'com.leocardz:link-preview:2.0.0@aar'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 9
@@ -22,8 +21,8 @@ android {
 }
 
 dependencies {
-    compile 'org.jsoup:jsoup:1.10.3'
+    implementation 'org.jsoup:jsoup:1.11.3'
 
-    androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }

--- a/library/src/androidTest/java/com/leocardz/link/preview/library/ProvidedDocumentTextCrawler.java
+++ b/library/src/androidTest/java/com/leocardz/link/preview/library/ProvidedDocumentTextCrawler.java
@@ -1,0 +1,28 @@
+package com.leocardz.link.preview.library;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+import java.io.IOException;
+
+/**
+ * A TextCrawler that allows you to provide the raw HTML that you would like to use for testing.
+ */
+public class ProvidedDocumentTextCrawler extends TextCrawler {
+    private final String html;
+
+    public ProvidedDocumentTextCrawler(final String html) {
+        this.html = html;
+    }
+
+    @Override
+    protected GetCode createPreviewGenerator(ImagePickingStrategy imagePickingStrategy) {
+        return new GetCode(imagePickingStrategy) {
+
+            @Override
+            protected Document getDocument() throws IOException {
+                return Jsoup.parse(html);
+            }
+        };
+    }
+}

--- a/library/src/androidTest/java/com/leocardz/link/preview/library/TestLinkPreviewCallback.java
+++ b/library/src/androidTest/java/com/leocardz/link/preview/library/TestLinkPreviewCallback.java
@@ -1,0 +1,29 @@
+package com.leocardz.link.preview.library;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * A LinkPreviewCallback that allows the test to wait until parsing is complete before evaluating.
+ */
+class TestLinkPreviewCallback implements LinkPreviewCallback {
+    SourceContent sourceContent;
+    boolean isNull;
+    final CountDownLatch signal;
+
+    public TestLinkPreviewCallback(CountDownLatch signal) {
+        super();
+        this.signal = signal;
+    }
+
+    @Override
+    public void onPre() {
+
+    }
+
+    @Override
+    public void onPos(SourceContent sourceContent, boolean isNull) {
+        this.sourceContent = sourceContent;
+        this.isNull = isNull;
+        signal.countDown();
+    }
+}

--- a/library/src/androidTest/java/com/leocardz/link/preview/library/TextCrawlerImageTest.java
+++ b/library/src/androidTest/java/com/leocardz/link/preview/library/TextCrawlerImageTest.java
@@ -1,0 +1,181 @@
+package com.leocardz.link.preview.library;
+
+import android.os.AsyncTask;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Instrumentation tests for TextCrawler Image handling.
+ */
+@RunWith(AndroidJUnit4.class)
+public class TextCrawlerImageTest {
+    @Test
+    public void documentWithMetaImageAndDefaultStrategyReturnsMetaImage() throws Throwable {
+        final String expectedImageUrl = "http://www.example.com/expected.jpg";
+        final String testHtml = "<!doctype html>\n" +
+                "<head>\n" +
+                "  <meta charset=\"utf-8\">\n" +
+                "  <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\">\n" +
+                "  <title>\n" +
+                "  Threddies - Bulk Headbands, Scrunchies, Ponytail Elastics, Hair Ties &ndash; threddies\n" +
+                "  </title>\n" +
+                "<meta property=\"og:site_name\" content=\"threddies\">\n" +
+                "<meta property=\"og:url\" content=\"https://threddies.com/\">\n" +
+                "<meta property=\"og:title\" content=\"Threddies - Bulk Headbands, Scrunchies, Ponytail Elastics, Hair Ties\">\n" +
+                "<meta property=\"og:type\" content=\"website\">\n" +
+                "<meta property=\"og:description\" content=\"Knit headbands, ponytail holders, scrunchies, satin headbands, non-slip headbands, hair elastics, turban headbands and beyond - at bulk pack wholesale prices!\">\n" +
+                "<meta property=\"og:image\" content=\"" + expectedImageUrl + "\">\n" +
+                "<meta name=\"twitter:site\" content=\"@threddies\">\n" +
+                "<meta name=\"twitter:card\" content=\"summary_large_image\">\n" +
+                "<meta name=\"twitter:title\" content=\"Threddies - Bulk Headbands, Scrunchies, Ponytail Elastics, Hair Ties\">\n" +
+                "<meta name=\"twitter:description\" content=\"Knit headbands, ponytail holders, scrunchies, satin headbands, non-slip headbands, hair elastics, turban headbands and beyond - at bulk pack wholesale prices!\">\n" +
+                "</head>\n" +
+                "\n" +
+                "<body>\n" +
+                "              <img src=\"http://www.example.com/notexpected.jpg\"\n" +
+                "                alt=\"Threddies: Peace, Love, Headbands\"\n" +
+                "                itemprop=\"logo\"\n" +
+                "                style=\"max-width:380px;\">\n" +
+                "</body>\n" +
+                "</html>\n";
+        final TextCrawler textCrawler = new ProvidedDocumentTextCrawler(testHtml);
+        final CountDownLatch signal = new CountDownLatch(1);
+        final TestLinkPreviewCallback callback = new TestLinkPreviewCallback(signal);
+        textCrawler.makePreview(callback, "https://www.example.com");
+        signal.await();
+
+        final SourceContent sourceContent = callback.sourceContent;
+        assertNotNull(sourceContent);
+        assertTrue(sourceContent.isSuccess());
+        assertFalse(callback.isNull);
+        final List<String> images = sourceContent.getImages();
+        assertNotNull(images);
+        assertEquals(1, images.size());
+        assertEquals(expectedImageUrl, images.get(0));
+    }
+
+    @Test
+    public void documentWithNoMetaImageAndDefaultStrategyReturnsImage() throws Throwable {
+        final String expectedImageUrl = "http://www.example.com/expected.jpg";
+        final String testHtml = "<!doctype html>\n" +
+                "<head>\n" +
+                "  <meta charset=\"utf-8\">\n" +
+                "  <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\">\n" +
+                "  <title>\n" +
+                "  Threddies - Bulk Headbands, Scrunchies, Ponytail Elastics, Hair Ties &ndash; threddies\n" +
+                "  </title>\n" +
+                "<meta property=\"og:site_name\" content=\"threddies\">\n" +
+                "<meta property=\"og:url\" content=\"https://threddies.com/\">\n" +
+                "<meta property=\"og:title\" content=\"Threddies - Bulk Headbands, Scrunchies, Ponytail Elastics, Hair Ties\">\n" +
+                "<meta property=\"og:type\" content=\"website\">\n" +
+                "<meta property=\"og:description\" content=\"Knit headbands, ponytail holders, scrunchies, satin headbands, non-slip headbands, hair elastics, turban headbands and beyond - at bulk pack wholesale prices!\">\n" +
+                "<meta name=\"twitter:site\" content=\"@threddies\">\n" +
+                "<meta name=\"twitter:card\" content=\"summary_large_image\">\n" +
+                "<meta name=\"twitter:title\" content=\"Threddies - Bulk Headbands, Scrunchies, Ponytail Elastics, Hair Ties\">\n" +
+                "<meta name=\"twitter:description\" content=\"Knit headbands, ponytail holders, scrunchies, satin headbands, non-slip headbands, hair elastics, turban headbands and beyond - at bulk pack wholesale prices!\">\n" +
+                "</head>\n" +
+                "\n" +
+                "<body>\n" +
+                "              <img src=\"" + expectedImageUrl + "\"\n" +
+                "                alt=\"Threddies: Peace, Love, Headbands\"\n" +
+                "                itemprop=\"logo\"\n" +
+                "                style=\"max-width:380px;\">\n" +
+                "</body>\n" +
+                "</html>\n";
+        final TextCrawler textCrawler = new ProvidedDocumentTextCrawler(testHtml);
+        final CountDownLatch signal = new CountDownLatch(1);
+        final TestLinkPreviewCallback callback = new TestLinkPreviewCallback(signal);
+        textCrawler.makePreview(callback, "https://www.example.com");
+        signal.await();
+
+        final SourceContent sourceContent = callback.sourceContent;
+        assertNotNull(sourceContent);
+        assertTrue(sourceContent.isSuccess());
+        assertFalse(callback.isNull);
+        final List<String> images = sourceContent.getImages();
+        assertNotNull(images);
+        assertEquals(1, images.size());
+        assertEquals(expectedImageUrl, images.get(0));
+    }
+
+    @Test
+    public void documentWithMetaImageAndCustomStrategyReturnsImage() throws Throwable {
+        final String expectedImageUrl = "http://www.example.com/expected.jpg";
+        final String testHtml = "<!doctype html>\n" +
+                "<head>\n" +
+                "  <meta charset=\"utf-8\">\n" +
+                "  <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\">\n" +
+                "  <title>\n" +
+                "  Threddies - Bulk Headbands, Scrunchies, Ponytail Elastics, Hair Ties &ndash; threddies\n" +
+                "  </title>\n" +
+                "<meta property=\"og:site_name\" content=\"threddies\">\n" +
+                "<meta property=\"og:url\" content=\"https://threddies.com/\">\n" +
+                "<meta property=\"og:title\" content=\"Threddies - Bulk Headbands, Scrunchies, Ponytail Elastics, Hair Ties\">\n" +
+                "<meta property=\"og:type\" content=\"website\">\n" +
+                "<meta property=\"og:description\" content=\"Knit headbands, ponytail holders, scrunchies, satin headbands, non-slip headbands, hair elastics, turban headbands and beyond - at bulk pack wholesale prices!\">\n" +
+                "<meta property=\"og:image\" content=\"http://www.example.com/notexpected.jpg\">\n" +
+                "<meta name=\"twitter:site\" content=\"@threddies\">\n" +
+                "<meta name=\"twitter:card\" content=\"summary_large_image\">\n" +
+                "<meta name=\"twitter:title\" content=\"Threddies - Bulk Headbands, Scrunchies, Ponytail Elastics, Hair Ties\">\n" +
+                "<meta name=\"twitter:description\" content=\"Knit headbands, ponytail holders, scrunchies, satin headbands, non-slip headbands, hair elastics, turban headbands and beyond - at bulk pack wholesale prices!\">\n" +
+                "</head>\n" +
+                "\n" +
+                "<body>\n" +
+                "              <img src=\"" + expectedImageUrl + "\"\n" +
+                "                alt=\"Threddies: Peace, Love, Headbands\"\n" +
+                "                itemprop=\"logo\"\n" +
+                "                style=\"max-width:380px;\">\n" +
+                "</body>\n" +
+                "</html>\n";
+        final TextCrawler textCrawler = new ProvidedDocumentTextCrawler(testHtml);
+        final CountDownLatch signal = new CountDownLatch(1);
+        final TestLinkPreviewCallback callback = new TestLinkPreviewCallback(signal);
+        textCrawler.makePreview(callback, "https://www.example.com", new BaseImagePickingStrategy() {
+
+            @Override
+            public List<String> getImages(AsyncTask asyncTask, Document document, HashMap<String, String> metaTags) {
+                List<String> images = new ArrayList<>();
+
+                Elements media = document.select("[src]");
+
+                for (Element srcElement : media) {
+                    if (asyncTask.isCancelled()) {
+                        break;
+                    }
+                    if (srcElement.tagName().equals("img")) {
+                        images.add(srcElement.attr("abs:src"));
+                        if (getImageQuantity() != TextCrawler.ALL && images.size() == getImageQuantity()) {
+                            break;
+                        }
+                    }
+                }
+                return images;
+            }
+        });
+        signal.await();
+
+        final SourceContent sourceContent = callback.sourceContent;
+        assertNotNull(sourceContent);
+        assertTrue(sourceContent.isSuccess());
+        assertFalse(callback.isNull);
+        final List<String> images = sourceContent.getImages();
+        assertNotNull(images);
+        assertEquals(1, images.size());
+        assertEquals(expectedImageUrl, images.get(0));
+    }
+}

--- a/library/src/androidTest/java/com/leocardz/link/preview/library/TextCrawlerTest.java
+++ b/library/src/androidTest/java/com/leocardz/link/preview/library/TextCrawlerTest.java
@@ -38,8 +38,8 @@ public class TextCrawlerTest {
     private class JSoupFailingTextCrawler extends TextCrawler {
 
         @Override
-        protected GetCode createPreviewGenerator(int imageQuantity) {
-            return new GetCode(imageQuantity) {
+        protected GetCode createPreviewGenerator(ImagePickingStrategy imagePickingStrategy) {
+            return new GetCode(imagePickingStrategy) {
 
                 @Override
                 protected Document getDocument() throws IOException {
@@ -49,26 +49,4 @@ public class TextCrawlerTest {
         }
     }
 
-    private class TestLinkPreviewCallback implements LinkPreviewCallback {
-        SourceContent sourceContent;
-        boolean isNull;
-        final CountDownLatch signal;
-
-        public TestLinkPreviewCallback(CountDownLatch signal) {
-            super();
-            this.signal = signal;
-        }
-
-        @Override
-        public void onPre() {
-
-        }
-
-        @Override
-        public void onPos(SourceContent sourceContent, boolean isNull) {
-            this.sourceContent = sourceContent;
-            this.isNull = isNull;
-            signal.countDown();
-        }
-    }
 }

--- a/library/src/main/java/com/leocardz/link/preview/library/BaseImagePickingStrategy.java
+++ b/library/src/main/java/com/leocardz/link/preview/library/BaseImagePickingStrategy.java
@@ -1,0 +1,15 @@
+package com.leocardz.link.preview.library;
+
+public abstract class BaseImagePickingStrategy implements ImagePickingStrategy {
+    private int imageQuantity = TextCrawler.ALL;
+
+    @Override
+    public void setImageQuantity(int imageQuantity) {
+        this.imageQuantity = imageQuantity;
+    }
+
+    @Override
+    public int getImageQuantity() {
+        return imageQuantity;
+    }
+}

--- a/library/src/main/java/com/leocardz/link/preview/library/DefaultImagePickingStrategy.java
+++ b/library/src/main/java/com/leocardz/link/preview/library/DefaultImagePickingStrategy.java
@@ -1,0 +1,46 @@
+package com.leocardz.link.preview.library;
+
+import android.os.AsyncTask;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * ImagePickingStrategy that mimics the original behavior of TextCrawler.  If a meta image tag exists,
+ * it is used, if not, the document is scraped to find other images.
+ */
+class DefaultImagePickingStrategy extends BaseImagePickingStrategy {
+
+    /**
+     * Gets images from the html code
+     */
+    @Override
+    public List<String> getImages(AsyncTask asyncTask, Document document, HashMap<String, String> metaTags) {
+        List<String> images = new ArrayList<>();
+        final String metaImage = metaTags.get("image");
+
+        if (!metaImage.equals("")) {
+            images.add(metaImage);
+        } else {
+            Elements media = document.select("[src]");
+
+            for (Element srcElement : media) {
+                if (asyncTask.isCancelled()) {
+                    break;
+                }
+                if (srcElement.tagName().equals("img")) {
+                    images.add(srcElement.attr("abs:src"));
+                    if (getImageQuantity() != TextCrawler.ALL && images.size() == getImageQuantity()) {
+                        break;
+                    }
+                }
+            }
+        }
+        return images;
+    }
+}

--- a/library/src/main/java/com/leocardz/link/preview/library/ImagePickingStrategy.java
+++ b/library/src/main/java/com/leocardz/link/preview/library/ImagePickingStrategy.java
@@ -1,0 +1,20 @@
+package com.leocardz.link.preview.library;
+
+import android.os.AsyncTask;
+
+import org.jsoup.nodes.Document;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * A strategy for how to select the images to return.
+ */
+public interface ImagePickingStrategy {
+
+    void setImageQuantity(int imageQuantity);
+
+    int getImageQuantity();
+
+    List<String> getImages(AsyncTask asyncTask, Document doc, HashMap<String, String> metaTags);
+}


### PR DESCRIPTION
This PR consists of two commits.  

The first updates the project so that it can be built with the latest version of Android Studio and updates the JSoup version.

The second commit adds the notion of an 'ImagePickingStrategy' this gives the library user the capability of overriding the default logic that is used in determining which images are returned by the crawling process.  This commit also has some optimizations in image picking and some scoping changes to make modifying the library in the future without negatively impacting backwards compatibility.  Tests were provided for the new functionality.