### PR TITLE
Enhancements to image resolution capabilities

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
 }
 
 dependencies {
+    implementation project(":library")
     implementation 'com.android.support:appcompat-v7:23.1.1'
     implementation 'com.koushikdutta.urlimageviewhelper:urlimageviewhelper:1.0.4'
     implementation 'org.jsoup:jsoup:1.11.3'
-    implementation 'com.leocardz:link-preview:2.0.0@aar'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/library/src/androidTest/java/com/leocardz/link/preview/library/TextCrawlerImageTest.java
+++ b/library/src/androidTest/java/com/leocardz/link/preview/library/TextCrawlerImageTest.java
@@ -178,4 +178,45 @@ public class TextCrawlerImageTest {
         assertEquals(1, images.size());
         assertEquals(expectedImageUrl, images.get(0));
     }
+
+
+    @Test
+    public void directLinkToImageThatEndsInFileExtensionReturnsImage() throws Throwable {
+        final String expectedImageUrl = "https://cdn.shopify.com/s/files/1/1400/5075/files/website_logo2_720x_6cdc3363-fec0-4d60-a5bd-5236869352bf_720x.png";
+
+        final TextCrawler textCrawler = new TextCrawler();
+        final CountDownLatch signal = new CountDownLatch(1);
+        final TestLinkPreviewCallback callback = new TestLinkPreviewCallback(signal);
+        textCrawler.makePreview(callback, expectedImageUrl);
+        signal.await();
+
+        final SourceContent sourceContent = callback.sourceContent;
+        assertNotNull(sourceContent);
+        assertTrue(sourceContent.isSuccess());
+        assertFalse(callback.isNull);
+        final List<String> images = sourceContent.getImages();
+        assertNotNull(images);
+        assertEquals(1, images.size());
+        assertEquals(expectedImageUrl, images.get(0));
+    }
+
+    @Test
+    public void directLinkToImageThatDoesNotEndInFileExtensionReturnsImage() throws Throwable {
+        final String expectedImageUrl = "https://cdn.shopify.com/s/files/1/1400/5075/files/website_logo2_720x_6cdc3363-fec0-4d60-a5bd-5236869352bf_720x.png?v=1533741874";
+
+        final TextCrawler textCrawler = new TextCrawler();
+        final CountDownLatch signal = new CountDownLatch(1);
+        final TestLinkPreviewCallback callback = new TestLinkPreviewCallback(signal);
+        textCrawler.makePreview(callback, expectedImageUrl);
+        signal.await();
+
+        final SourceContent sourceContent = callback.sourceContent;
+        assertNotNull(sourceContent);
+        assertTrue(sourceContent.isSuccess());
+        assertFalse(callback.isNull);
+        final List<String> images = sourceContent.getImages();
+        assertNotNull(images);
+        assertEquals(1, images.size());
+        assertEquals(expectedImageUrl, images.get(0));
+    }
 }

--- a/library/src/main/java/com/leocardz/link/preview/library/BaseImagePickingStrategy.java
+++ b/library/src/main/java/com/leocardz/link/preview/library/BaseImagePickingStrategy.java
@@ -1,5 +1,15 @@
 package com.leocardz.link.preview.library;
 
+import android.os.AsyncTask;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 public abstract class BaseImagePickingStrategy implements ImagePickingStrategy {
     private int imageQuantity = TextCrawler.ALL;
 
@@ -11,5 +21,33 @@ public abstract class BaseImagePickingStrategy implements ImagePickingStrategy {
     @Override
     public int getImageQuantity() {
         return imageQuantity;
+    }
+
+    protected List<String> getMetaImage(HashMap<String, String> metaTags) {
+        List<String> images = new ArrayList<>();
+        final String metaImage = metaTags.get("image");
+
+        if (!metaImage.equals("")) {
+            images.add(metaImage);
+        }
+        return images;
+    }
+
+    protected List<String> getImagesFromImgTags(AsyncTask asyncTask, Document document) {
+        List<String> images = new ArrayList<>();
+        Elements media = document.select("[src]");
+
+        for (Element srcElement : media) {
+            if (asyncTask.isCancelled()) {
+                break;
+            }
+            if (srcElement.tagName().equals("img")) {
+                images.add(srcElement.attr("abs:src"));
+                if (getImageQuantity() != TextCrawler.ALL && images.size() == getImageQuantity()) {
+                    break;
+                }
+            }
+        }
+        return images;
     }
 }

--- a/library/src/main/java/com/leocardz/link/preview/library/DefaultImagePickingStrategy.java
+++ b/library/src/main/java/com/leocardz/link/preview/library/DefaultImagePickingStrategy.java
@@ -3,10 +3,7 @@ package com.leocardz.link.preview.library;
 import android.os.AsyncTask;
 
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -21,25 +18,10 @@ class DefaultImagePickingStrategy extends BaseImagePickingStrategy {
      */
     @Override
     public List<String> getImages(AsyncTask asyncTask, Document document, HashMap<String, String> metaTags) {
-        List<String> images = new ArrayList<>();
-        final String metaImage = metaTags.get("image");
+        List<String> images = getMetaImage(metaTags);
 
-        if (!metaImage.equals("")) {
-            images.add(metaImage);
-        } else {
-            Elements media = document.select("[src]");
-
-            for (Element srcElement : media) {
-                if (asyncTask.isCancelled()) {
-                    break;
-                }
-                if (srcElement.tagName().equals("img")) {
-                    images.add(srcElement.attr("abs:src"));
-                    if (getImageQuantity() != TextCrawler.ALL && images.size() == getImageQuantity()) {
-                        break;
-                    }
-                }
-            }
+        if (images.isEmpty()) {
+            images.addAll(getImagesFromImgTags(asyncTask, document));
         }
         return images;
     }


### PR DESCRIPTION
Currently sharing an image URL that does not end in a file extension (e.g. https://cdn.shopify.com/s/files/1/1400/5075/files/website_logo2_720x_6cdc3363-fec0-4d60-a5bd-5236869352bf_720x.png?v=1533741874) results in a failed preview rather than pulling back the correct image.

This occurs because these URLs do not match the regex used in isImage().  This results in an attempt by JSoup to process the image as an HTML document which results in an exception due to a check on the response mime type.  I added code to detect this error and process the url as if it were an image if the returned mimetype is an image.

I also updated the project to work with the newest Android Studio version and refactored DefaultImagePickingStrategy so that subclasses of BaseImagePickingStrategy can reuse the code for getting the image url from the meta tags and/or from scraping the HTML document.

The sample app was also updated to refer to the library project rather than pull the release artifact.