### PR TITLE
Add ability for library users to specify how to extract URLs from the…

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,4 +25,5 @@ dependencies {
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'org.mockito:mockito-android:2.22.0'
 }

--- a/library/src/androidTest/java/com/leocardz/link/preview/library/ProvidedDocumentTextCrawler.java
+++ b/library/src/androidTest/java/com/leocardz/link/preview/library/ProvidedDocumentTextCrawler.java
@@ -17,7 +17,7 @@ public class ProvidedDocumentTextCrawler extends TextCrawler {
 
     @Override
     protected GetCode createPreviewGenerator(ImagePickingStrategy imagePickingStrategy) {
-        return new GetCode(imagePickingStrategy) {
+        return new GetCode(imagePickingStrategy, null) {
 
             @Override
             protected Document getDocument() throws IOException {

--- a/library/src/androidTest/java/com/leocardz/link/preview/library/TextCrawlerTest.java
+++ b/library/src/androidTest/java/com/leocardz/link/preview/library/TextCrawlerTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -49,6 +50,22 @@ public class TextCrawlerTest {
         signal.await();
 
         verify(mockUrlExtractionStrategy).extractUrls(textPassedToTextCrawler);
+    }
+
+    @Test
+    public void urlExhibitingInfiniteRedirectIssueCanBeProcessed() throws Throwable {
+        final CountDownLatch signal = new CountDownLatch(1);
+        final TextCrawler textCrawler = new TextCrawler();
+
+        final TestLinkPreviewCallback callback = new TestLinkPreviewCallback(signal);
+
+        textCrawler.makePreview(callback, "https://medium.muz.li/ui-design-tips-for-iphone-x-2652b2b248ce");
+        signal.await(5000, TimeUnit.MILLISECONDS);
+
+        final SourceContent sourceContent = callback.sourceContent;
+        assertNotNull(sourceContent);
+        assertTrue(sourceContent.isSuccess());
+        assertFalse(callback.isNull);
     }
 
     /**

--- a/library/src/main/java/com/leocardz/link/preview/library/TextCrawler.java
+++ b/library/src/main/java/com/leocardz/link/preview/library/TextCrawler.java
@@ -2,6 +2,9 @@ package com.leocardz.link.preview.library;
 
 import android.os.AsyncTask;
 
+import com.leocardz.link.preview.library.url.DefaultUrlExtractionStrategy;
+import com.leocardz.link.preview.library.url.UrlExtractionStrategy;
+
 import org.jsoup.Jsoup;
 import org.jsoup.UnsupportedMimeTypeException;
 import org.jsoup.nodes.Document;
@@ -10,7 +13,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -26,8 +28,10 @@ public class TextCrawler {
 
 	private AsyncTask getCodeTask;
 
-	public TextCrawler() {
-	}
+    private UrlExtractionStrategy urlExtractionStrategy;
+
+    public TextCrawler() {
+    }
 
     public void makePreview(LinkPreviewCallback callback, String url) {
         ImagePickingStrategy imagePickingStrategy = new DefaultImagePickingStrategy();
@@ -49,7 +53,7 @@ public class TextCrawler {
     }
 
     protected GetCode createPreviewGenerator(ImagePickingStrategy imagePickingStrategy) {
-        return new GetCode(imagePickingStrategy);
+        return new GetCode(imagePickingStrategy, urlExtractionStrategy);
     }
 
 	public void cancel(){
@@ -57,6 +61,10 @@ public class TextCrawler {
 			getCodeTask.cancel(true);
 		}
 	}
+
+    public void setUrlExtractionStrategy(UrlExtractionStrategy urlExtractionStrategy) {
+        this.urlExtractionStrategy = urlExtractionStrategy;
+    }
 
 
     /**
@@ -66,10 +74,14 @@ public class TextCrawler {
 
         private SourceContent sourceContent = new SourceContent();
         private final ImagePickingStrategy imagePickingStrategy;
-        private ArrayList<String> urls;
+        private final UrlExtractionStrategy urlExtractionStrategy;
 
-        GetCode(ImagePickingStrategy imagePickingStrategy) {
+        GetCode(ImagePickingStrategy imagePickingStrategy, UrlExtractionStrategy urlExtractionStrategy) {
             this.imagePickingStrategy = imagePickingStrategy;
+            if (urlExtractionStrategy == null) {
+                urlExtractionStrategy = new DefaultUrlExtractionStrategy();
+            }
+            this.urlExtractionStrategy = urlExtractionStrategy;
         }
 
         @Override
@@ -95,19 +107,18 @@ public class TextCrawler {
 
         @Override
         protected Void doInBackground(String... params) {
-            // Don't forget the http:// or https://
-            urls = SearchUrls.matches(params[0]);
+            final List<String> urlStrings = urlExtractionStrategy.extractUrls(params[0]);
+            String url;
+            if (urlStrings != null && !urlStrings.isEmpty()) {
+                url = unshortenUrl(urlStrings.get(0));
+            } else {
+                url = "";
+            }
 
-            if (urls.size() > 0)
-                sourceContent
-                        .setFinalUrl(unshortenUrl(extendedTrim(urls.get(0))));
-            else
-                sourceContent.setFinalUrl("");
-
+            sourceContent.setFinalUrl(url);
             boolean wasPreviewGenerationSuccessful = false;
-            if (!sourceContent.getFinalUrl().equals("")) {
-                if (isImage(sourceContent.getFinalUrl())
-                        && !sourceContent.getFinalUrl().contains("dropbox")) {
+            if (!url.equals("")) {
+                if (isImage(url) && !url.contains("dropbox")) {
                     setSourceContentForImage();
                     wasPreviewGenerationSuccessful = true;
                 } else {
@@ -232,30 +243,27 @@ public class TextCrawler {
 		return Jsoup.parse(content).text();
 	}
 
-	/** Crawls the code looking for relevant information */
-	private String crawlCode(String content) {
-		String result = "";
-		String resultSpan = "";
-		String resultParagraph = "";
-		String resultDiv = "";
+    /**
+     * Crawls the code looking for relevant information
+     */
+    private String crawlCode(String content) {
+        String resultSpan = getTagContent("span", content);
+        String resultParagraph = getTagContent("p", content);
+        String resultDiv = getTagContent("div", content);
 
-		resultSpan = getTagContent("span", content);
-		resultParagraph = getTagContent("p", content);
-		resultDiv = getTagContent("div", content);
+        String result;
 
-		result = resultSpan;
+        if (resultParagraph.length() > resultSpan.length()
+                && resultParagraph.length() >= resultDiv.length())
+            result = resultParagraph;
+        else if (resultParagraph.length() > resultSpan.length()
+                && resultParagraph.length() < resultDiv.length())
+            result = resultDiv;
+        else
+            result = resultParagraph;
 
-		if (resultParagraph.length() > resultSpan.length()
-				&& resultParagraph.length() >= resultDiv.length())
-			result = resultParagraph;
-		else if (resultParagraph.length() > resultSpan.length()
-				&& resultParagraph.length() < resultDiv.length())
-			result = resultDiv;
-		else
-			result = resultParagraph;
-
-		return htmlDecode(result);
-	}
+        return htmlDecode(result);
+    }
 
 	/** Returns the cannoncial url */
 	private String cannonicalPage(String url) {

--- a/library/src/main/java/com/leocardz/link/preview/library/TextCrawler.java
+++ b/library/src/main/java/com/leocardz/link/preview/library/TextCrawler.java
@@ -359,46 +359,69 @@ public class TextCrawler {
 		return htmlDecode(result);
 	}
 
-	/**
-	 * Unshortens a short url
-	 */
-	private String unshortenUrl(String shortURL) {
-		if (!shortURL.startsWith(HTTP_PROTOCOL)
-				&& !shortURL.startsWith(HTTPS_PROTOCOL))
-			return "";
+    /**
+     * Unshortens a short url
+     */
+    private String unshortenUrl(final String originURL) {
+        if (!originURL.startsWith(HTTP_PROTOCOL)
+                && !originURL.startsWith(HTTPS_PROTOCOL))
+            return "";
 
-		URLConnection urlConn = connectURL(shortURL);
-		urlConn.getHeaderFields();
+        URLConnection urlConn = connectURL(originURL);
+        urlConn.getHeaderFields();
 
-		String finalResult = urlConn.getURL().toString();
+        final URL finalUrl = urlConn.getURL();
 
-		urlConn = connectURL(finalResult);
-		urlConn.getHeaderFields();
+        urlConn = connectURL(finalUrl);
+        urlConn.getHeaderFields();
 
-		shortURL = urlConn.getURL().toString();
+        final URL shortURL = urlConn.getURL();
 
-		while (!shortURL.equals(finalResult)) {
-			finalResult = unshortenUrl(finalResult);
-		}
+        String finalResult = shortURL.toString();
 
-		return finalResult;
-	}
+        while (!shortURL.sameFile(finalUrl)) {
+            boolean isEndlesslyRedirecting = false;
+            if (shortURL.getHost().equals(finalUrl.getHost())) {
+                if (shortURL.getPath().equals(finalUrl.getPath())) {
+                    isEndlesslyRedirecting = true;
+                }
+            }
+            if (isEndlesslyRedirecting) {
+                break;
+            } else {
+                finalResult = unshortenUrl(shortURL.toString());
+            }
+        }
 
-	/**
-	 * Takes a valid url and return a URL object representing the url address.
-	 */
-	private URLConnection connectURL(String strURL) {
-		URLConnection conn = null;
-		try {
-			URL inputURL = new URL(strURL);
-			conn = inputURL.openConnection();
-		} catch (MalformedURLException e) {
-			System.out.println("Please input a valid URL");
-		} catch (IOException ioe) {
-			System.out.println("Can not connect to the URL");
-		}
-		return conn;
-	}
+        return finalResult;
+    }
+
+    /**
+     * Takes a valid url string and returns a URLConnection object for the url.
+     */
+    private URLConnection connectURL(String strURL) {
+        URLConnection conn = null;
+        try {
+            URL inputURL = new URL(strURL);
+            conn = connectURL(inputURL);
+        } catch (MalformedURLException e) {
+            System.out.println("Please input a valid URL");
+        }
+        return conn;
+    }
+
+    /**
+     * Takes a valid url and returns a URLConnection object for the url.
+     */
+    private URLConnection connectURL(URL inputURL) {
+        URLConnection conn = null;
+        try {
+            conn = inputURL.openConnection();
+        } catch (IOException ioe) {
+            System.out.println("Can not connect to the URL");
+        }
+        return conn;
+    }
 
 	/** Removes extra spaces and trim the string */
 	public static String extendedTrim(String content) {

--- a/library/src/main/java/com/leocardz/link/preview/library/url/DefaultUrlExtractionStrategy.java
+++ b/library/src/main/java/com/leocardz/link/preview/library/url/DefaultUrlExtractionStrategy.java
@@ -1,0 +1,21 @@
+package com.leocardz.link.preview.library.url;
+
+import com.leocardz.link.preview.library.SearchUrls;
+import com.leocardz.link.preview.library.TextCrawler;
+
+import java.util.List;
+
+public class DefaultUrlExtractionStrategy implements UrlExtractionStrategy {
+
+    @Override
+    public List<String> extractUrls(String textPassedToTextCrawler) {
+        // Don't forget the http:// or https://
+        List<String> urls = SearchUrls.matches(textPassedToTextCrawler);
+
+        if (urls.size() > 0) {
+            String url = TextCrawler.extendedTrim(urls.get(0));
+            urls.set(0, url);
+        }
+        return urls;
+    }
+}

--- a/library/src/main/java/com/leocardz/link/preview/library/url/UrlExtractionStrategy.java
+++ b/library/src/main/java/com/leocardz/link/preview/library/url/UrlExtractionStrategy.java
@@ -1,0 +1,10 @@
+package com.leocardz.link.preview.library.url;
+
+import java.util.List;
+
+/**
+ * Provides the means for extracting URL(s) from text.
+ */
+public interface UrlExtractionStrategy {
+    List<String> extractUrls(String textPassedToTextCrawler);
+}


### PR DESCRIPTION
… passed text


I updated TextCrawler to allow users of the library to specify how they want to pull URLs from the passed in text.  Users who choose not to do this still get the old behavior by default.  I added a few tests and the Mockito library to support better tests in the future.  I also added some performance enhancements in the form of eliminating unnecessary string creation/manipulation.